### PR TITLE
Remove most transmutes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 .cargo/config
 src/bin/*
 TODO.txt
+/.vscode

--- a/src/async_pinger.rs
+++ b/src/async_pinger.rs
@@ -64,7 +64,7 @@ use std::{
  */
 
 use crate::{
-    util::{windows_ipv6, windows_ipv4},
+    util::{windows_ipv4, windows_ipv6},
     Buffer, Error, IpPair,
 };
 /// A pinger that does not block when sending.

--- a/src/async_pinger.rs
+++ b/src/async_pinger.rs
@@ -64,7 +64,7 @@ use std::{
  */
 
 use crate::{
-    util::{rip6_to_wip6, rip_to_wip},
+    util::{windows_ipv6, windows_ipv4},
     Buffer, Error, IpPair,
 };
 /// A pinger that does not block when sending.
@@ -422,8 +422,8 @@ fn try_recv_job(rx: &Receiver<Job>) -> bool {
                     NULL,             // Event
                     callback_fn as _, // ApcRoutine,
                     arcptr as _,      // ApcContext,
-                    rip_to_wip(src),
-                    rip_to_wip(dst),
+                    windows_ipv4(src),
+                    windows_ipv4(dst),
                     job.data_ptr,
                     job.data_len,
                     &mut ip_opts,
@@ -441,7 +441,7 @@ fn try_recv_job(rx: &Receiver<Job>) -> bool {
                     NULL,             // Event
                     callback_fn as _, // ApcRoutine,
                     arcptr as _,      // ApcContext,
-                    rip_to_wip(dst),
+                    windows_ipv4(dst),
                     job.data_ptr,
                     job.data_len,
                     &mut ip_opts,
@@ -455,12 +455,12 @@ fn try_recv_job(rx: &Receiver<Job>) -> bool {
         V6 { src, dst } => {
             let mut src = SOCKADDR_IN6 {
                 sin6_family: AF_INET6 as _,
-                sin6_addr: rip6_to_wip6(src.unwrap_or(Ipv6Addr::UNSPECIFIED)),
+                sin6_addr: windows_ipv6(src.unwrap_or(Ipv6Addr::UNSPECIFIED)),
                 ..Default::default()
             };
             let mut dst = SOCKADDR_IN6 {
                 sin6_family: AF_INET6 as _,
-                sin6_addr: rip6_to_wip6(dst),
+                sin6_addr: windows_ipv6(dst),
                 ..Default::default()
             };
             let ret = unsafe {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -7,9 +7,11 @@ use winapi::{
 };
 
 use std::{
-    mem::{self, align_of, size_of},
+    mem::{align_of, size_of},
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
+
+use crate::util::{wip6_to_rip6, wip_to_rip};
 
 // Chunk is a lump of u8, apropriately sized and aligned
 // for the necessary ICMP(V6)_ECHO_REPLY(32) types on
@@ -186,7 +188,7 @@ impl Buffer {
             ReplyState::Filled4 { .. } => self.as_echo_reply().unwrap().Address,
             _ => return None,
         };
-        Some(unsafe { mem::transmute(addr) })
+        Some(wip_to_rip(addr))
     }
     /// Gets the responding Ipv6Addr from the last request this buffer was involved in. Returns None
     /// if the last request was v4, the buffer wasn't used in a request, or there was no reply.
@@ -195,7 +197,7 @@ impl Buffer {
             ReplyState::Filled6 { .. } => self.as_echo_reply6().unwrap().Address.sin6_addr,
             _ => return None,
         };
-        Some(unsafe { mem::transmute(addr) })
+        Some(wip6_to_rip6(addr))
     }
     /// Gets the responding IpAddr from the last request this buffer was involved in. Returns None
     /// if the buffer wasn't used in a request, or there was no reply.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -11,7 +11,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
 
-use crate::util::{wip6_to_rip6, wip_to_rip};
+use crate::util::{rust_ipv6, rust_ipv4};
 
 // Chunk is a lump of u8, apropriately sized and aligned
 // for the necessary ICMP(V6)_ECHO_REPLY(32) types on
@@ -188,7 +188,7 @@ impl Buffer {
             ReplyState::Filled4 { .. } => self.as_echo_reply().unwrap().Address,
             _ => return None,
         };
-        Some(wip_to_rip(addr))
+        Some(rust_ipv4(addr))
     }
     /// Gets the responding Ipv6Addr from the last request this buffer was involved in. Returns None
     /// if the last request was v4, the buffer wasn't used in a request, or there was no reply.
@@ -197,7 +197,7 @@ impl Buffer {
             ReplyState::Filled6 { .. } => self.as_echo_reply6().unwrap().Address.sin6_addr,
             _ => return None,
         };
-        Some(wip6_to_rip6(addr))
+        Some(rust_ipv6(addr))
     }
     /// Gets the responding IpAddr from the last request this buffer was involved in. Returns None
     /// if the buffer wasn't used in a request, or there was no reply.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -11,7 +11,7 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
 
-use crate::util::{rust_ipv6, rust_ipv4};
+use crate::util::{rust_ipv4, rust_ipv6};
 
 // Chunk is a lump of u8, apropriately sized and aligned
 // for the necessary ICMP(V6)_ECHO_REPLY(32) types on

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ mod async_pinger;
 mod buffer;
 mod error;
 mod pinger;
+pub(crate) mod util;
 
 #[cfg(feature = "async")]
 pub use async_pinger::{set_async_buffer_size, AsyncPinger, AsyncResult, PingFuture};

--- a/src/pinger.rs
+++ b/src/pinger.rs
@@ -27,7 +27,7 @@ use std::{
 };
 
 use crate::{
-    util::{windows_ipv6, windows_ipv4},
+    util::{windows_ipv4, windows_ipv6},
     Buffer, Error,
 };
 

--- a/src/pinger.rs
+++ b/src/pinger.rs
@@ -27,7 +27,7 @@ use std::{
 };
 
 use crate::{
-    util::{rip6_to_wip6, rip_to_wip},
+    util::{windows_ipv6, windows_ipv4},
     Buffer, Error,
 };
 
@@ -158,7 +158,7 @@ impl Pinger {
         let ret = unsafe {
             IcmpSendEcho(
                 self.handles.v4,
-                rip_to_wip(dst),
+                windows_ipv4(dst),
                 buf.request_data_ptr(),
                 buf.request_data_len(),
                 &mut self.make_ip_opts(),
@@ -189,8 +189,8 @@ impl Pinger {
                 NULL,      // Event
                 NULL as _, // ApcRoutine
                 NULL,      // ApcContext
-                rip_to_wip(src),
-                rip_to_wip(dst),
+                windows_ipv4(src),
+                windows_ipv4(dst),
                 buf.request_data_ptr(),
                 buf.request_data_len(),
                 &mut self.make_ip_opts(),
@@ -216,7 +216,7 @@ impl Pinger {
     pub fn send6(&self, dst: Ipv6Addr, buf: &mut Buffer) -> Result<u32, Error> {
         let mut dst = SOCKADDR_IN6 {
             sin6_family: AF_INET6 as _,
-            sin6_addr: rip6_to_wip6(dst),
+            sin6_addr: windows_ipv6(dst),
             ..Default::default()
         };
         buf.init_for_send();
@@ -254,12 +254,12 @@ impl Pinger {
     pub fn send6_from(&self, src: Ipv6Addr, dst: Ipv6Addr, buf: &mut Buffer) -> Result<u32, Error> {
         let mut dst = SOCKADDR_IN6 {
             sin6_family: AF_INET6 as _,
-            sin6_addr: rip6_to_wip6(dst),
+            sin6_addr: windows_ipv6(dst),
             ..Default::default()
         };
         let mut src = SOCKADDR_IN6 {
             sin6_family: AF_INET6 as _,
-            sin6_addr: rip6_to_wip6(src),
+            sin6_addr: windows_ipv6(src),
             ..Default::default()
         };
         buf.init_for_send();

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,46 @@
+use winapi::shared::in6addr::in6_addr;
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+/// Converts a Rust IPv4 to a Windows IPv4
+pub(crate) fn rip_to_wip(ip: Ipv4Addr) -> u32 {
+    u32::from_ne_bytes(ip.octets())
+}
+/// Converts a Windows IPv4 to a Rust IPv4
+pub(crate) fn wip_to_rip(ip: u32) -> Ipv4Addr {
+    Ipv4Addr::from(ip.to_ne_bytes())
+}
+/// Converts a Rust IPv6 to a Windows IPv6
+pub(crate) fn rip6_to_wip6(ip: Ipv6Addr) -> in6_addr {
+    // Unsafe can't be avoided when creating an in6_addr,
+    // so might as well just transmute it.
+    unsafe { std::mem::transmute(ip) }
+}
+/// Converts a Windows IPv6 to a Rust IPv6
+#[allow(clippy::many_single_char_names)]
+pub(crate) fn wip6_to_rip6(ip: [u16; 8]) -> Ipv6Addr {
+    let [a, b, c, d, e, f, g, h] = ip;
+    Ipv6Addr::new(
+        u16::from_be(a),
+        u16::from_be(b),
+        u16::from_be(c),
+        u16::from_be(d),
+        u16::from_be(e),
+        u16::from_be(f),
+        u16::from_be(g),
+        u16::from_be(h),
+    )
+}
+
+#[test]
+#[allow(clippy::many_single_char_names)]
+fn ip_conv_is_correct() {
+    let localhost_u32be: u32 = 0x7f000001u32.to_be();
+    assert_eq!(localhost_u32be, rip_to_wip(Ipv4Addr::LOCALHOST));
+    assert_eq!(Ipv4Addr::LOCALHOST, wip_to_rip(localhost_u32be));
+
+    let localhost6_segments_be = [0, 0, 0, 0, 0, 0, 0, 1u16.to_be()];
+    assert_eq!(localhost6_segments_be, *unsafe {
+        rip6_to_wip6(Ipv6Addr::LOCALHOST).u.Word()
+    });
+    assert_eq!(Ipv6Addr::LOCALHOST, wip6_to_rip6(localhost6_segments_be));
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,22 +2,22 @@ use winapi::shared::in6addr::in6_addr;
 
 use std::net::{Ipv4Addr, Ipv6Addr};
 /// Converts a Rust IPv4 to a Windows IPv4
-pub(crate) fn rip_to_wip(ip: Ipv4Addr) -> u32 {
+pub(crate) fn windows_ipv4(ip: Ipv4Addr) -> u32 {
     u32::from_ne_bytes(ip.octets())
 }
 /// Converts a Windows IPv4 to a Rust IPv4
-pub(crate) fn wip_to_rip(ip: u32) -> Ipv4Addr {
+pub(crate) fn rust_ipv4(ip: u32) -> Ipv4Addr {
     Ipv4Addr::from(ip.to_ne_bytes())
 }
 /// Converts a Rust IPv6 to a Windows IPv6
-pub(crate) fn rip6_to_wip6(ip: Ipv6Addr) -> in6_addr {
+pub(crate) fn windows_ipv6(ip: Ipv6Addr) -> in6_addr {
     // Unsafe can't be avoided when creating an in6_addr,
     // so might as well just transmute it.
     unsafe { std::mem::transmute(ip) }
 }
 /// Converts a Windows IPv6 to a Rust IPv6
 #[allow(clippy::many_single_char_names)]
-pub(crate) fn wip6_to_rip6(ip: [u16; 8]) -> Ipv6Addr {
+pub(crate) fn rust_ipv6(ip: [u16; 8]) -> Ipv6Addr {
     let [a, b, c, d, e, f, g, h] = ip;
     Ipv6Addr::new(
         u16::from_be(a),
@@ -35,12 +35,12 @@ pub(crate) fn wip6_to_rip6(ip: [u16; 8]) -> Ipv6Addr {
 #[allow(clippy::many_single_char_names)]
 fn ip_conv_is_correct() {
     let localhost_u32be: u32 = 0x7f000001u32.to_be();
-    assert_eq!(localhost_u32be, rip_to_wip(Ipv4Addr::LOCALHOST));
-    assert_eq!(Ipv4Addr::LOCALHOST, wip_to_rip(localhost_u32be));
+    assert_eq!(localhost_u32be, windows_ipv4(Ipv4Addr::LOCALHOST));
+    assert_eq!(Ipv4Addr::LOCALHOST, rust_ipv4(localhost_u32be));
 
     let localhost6_segments_be = [0, 0, 0, 0, 0, 0, 0, 1u16.to_be()];
     assert_eq!(localhost6_segments_be, *unsafe {
-        rip6_to_wip6(Ipv6Addr::LOCALHOST).u.Word()
+        windows_ipv6(Ipv6Addr::LOCALHOST).u.Word()
     });
-    assert_eq!(Ipv6Addr::LOCALHOST, wip6_to_rip6(localhost6_segments_be));
+    assert_eq!(Ipv6Addr::LOCALHOST, rust_ipv6(localhost6_segments_be));
 }


### PR DESCRIPTION
For self-review.

Removed transmutes that were being used to convert between Rust and Windows IP(v4|v6) addresses.

One bit of `unsafe` appears to be unavoidable when constructing a Windows `in6_addr`